### PR TITLE
Ensure scrollbars are shown

### DIFF
--- a/app/asset-select.html
+++ b/app/asset-select.html
@@ -10,7 +10,7 @@
 
 <script>
   function openChooser() {
-    window.open('http://localhost:9000/#/browser/assets/geometrixx-outdoors','asset-select','width=800,height=650,toolbar=no,left=200,top=200');
+    window.open('http://localhost:9000/#/browser/assets/geometrixx-outdoors','asset-select','width=800,height=650,toolbar=no,left=200,top=200,scrollbars=yes');
   }
 
   function insertImage(assetUrl) {


### PR DESCRIPTION
Large lists of assets may extend beyond the window viewable area. Ensureing the scrollbars allows to scroll down to them
